### PR TITLE
Correct reference to FBEHelper in BatchAPI Exception Handler

### DIFF
--- a/Facebook/BusinessExtension/Model/Product/Feed/Method/BatchApi.php
+++ b/Facebook/BusinessExtension/Model/Product/Feed/Method/BatchApi.php
@@ -98,7 +98,7 @@ class BatchApi
                         $exceptions++;
                         // Don't overload the logs, log the first 3 exceptions
                         if ($exceptions <= 3) {
-                            $this->_fbeHelper->logException($e);
+                            $this->fbeHelper->logException($e);
                         }
                         // If it looks like a systemic failure : stop feed generation
                         if ($exceptions > 100) {


### PR DESCRIPTION
This corrects an "Undefined Property" error in the exception handler.