### PR TITLE
Use the Product ID instead of the SKU in the Feed

### DIFF
--- a/Facebook/BusinessExtension/Model/Product/Feed/Builder.php
+++ b/Facebook/BusinessExtension/Model/Product/Feed/Builder.php
@@ -342,7 +342,7 @@ class Builder
         $imageUrl = $this->trimAttribute(self::ATTR_IMAGE_URL, $images['main_image']);
 
         $entry = [
-            self::ATTR_RETAILER_ID          => $this->trimAttribute(self::ATTR_RETAILER_ID, $product->getSku()),
+            self::ATTR_RETAILER_ID          => $this->trimAttribute(self::ATTR_RETAILER_ID, $product->getId()),
             self::ATTR_ITEM_GROUP_ID        => $this->getItemGroupId($product),
             self::ATTR_NAME                 => $productTitle,
             self::ATTR_DESCRIPTION          => $this->getDescription($product),


### PR DESCRIPTION
The pixel uses the product ID for matching events. 

See for example: https://github.com/facebookincubator/facebook-for-magento2/blob/791716e68d9fc685e4f550a4ba67f9fe743481b3/Facebook/BusinessExtension/Block/Pixel/ViewContent.php#L14

So the products should also be saved using the ID instead of the SKU.