### PR TITLE
Set the `content_type` correctly for configurable products

### DIFF
--- a/Facebook/BusinessExtension/Block/Pixel/ViewContent.php
+++ b/Facebook/BusinessExtension/Block/Pixel/ViewContent.php
@@ -5,6 +5,8 @@
 
 namespace Facebook\BusinessExtension\Block\Pixel;
 
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
+
 class ViewContent extends Common {
 
   public function getContentIDs() {
@@ -23,6 +25,11 @@ class ViewContent extends Common {
     } else {
       return null;
     }
+  }
+
+  public function getContentType() {
+    $product = $this->_registry->registry('current_product');
+    return ($product->getTypeId() == Configurable::TYPE_CODE) ? 'product_group' : 'product';
   }
 
   public function getContentCategory() {

--- a/Facebook/BusinessExtension/Observer/ViewContent.php
+++ b/Facebook/BusinessExtension/Observer/ViewContent.php
@@ -5,6 +5,7 @@
 
 namespace Facebook\BusinessExtension\Observer;
 
+use Magento\ConfigurableProduct\Model\Product\Type\Configurable;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 
@@ -47,8 +48,7 @@ class ViewContent implements ObserverInterface {
     try{
       $eventId = $observer->getData('eventId');
       $customData = [
-        'currency' => $this->_magentoDataHelper->getCurrency(),
-        'content_type' => 'product'
+        'currency' => $this->_magentoDataHelper->getCurrency()
       ];
       $product = $this->_registry->registry('current_product');
       if ($product && $product->getId()) {
@@ -62,6 +62,7 @@ class ViewContent implements ObserverInterface {
             'item_price' => $this->_magentoDataHelper->getValueForProduct($product)
           )
         ];
+        $customData['content_type'] = ($product->getTypeId() == Configurable::TYPE_CODE) ? 'product_group' : 'product';
       }
       $event = ServerEventFactory::createEvent('ViewContent', array_filter($customData), $eventId );
       $this->_serverSideHelper->sendEvent($event);


### PR DESCRIPTION
In the case of Configurable Products, the `content_ids` of the ViewContent event refers to the ID of the parent product. This ID is stored in the `item_group_id` of the individual products. The `content_type` property of the event should be set to `product_group` to reflect that.