### PR TITLE
Error fixed: Doesn't delete facebook's product.

### DIFF
--- a/Observer/ProcessProductAfterDeleteEventObserver.php
+++ b/Observer/ProcessProductAfterDeleteEventObserver.php
@@ -38,12 +38,16 @@ class ProcessProductAfterDeleteEventObserver implements ObserverInterface
         $product = $observer->getEvent()->getProduct();
 
         if ($product->getId()) {
-            $requestData = [];
-            $requestData['method'] = 'DELETE';
-            $requestData['retailer_id'] = $product->getId();
-            $requestParams = [];
-            $requestParams[0] = $requestData;
-            $response = $this->fbeHelper->makeHttpRequest($requestParams, null);
+            try {
+                $requestData = $this->batchApi->buildProductRequest($product);
+                $requestData['method'] = 'DELETE';
+                $requestData['retailer_id'] = $product->getId();
+                $requestParams = [];
+                $requestParams[0] = $requestData;
+                $response = $this->fbeHelper->makeHttpRequest($requestParams, null);
+            } catch (\Exception $e) {
+                $this->fbeHelper->logException($e);
+            }
         }
     }
 }


### PR DESCRIPTION
When I try to delete a product I get this response:

{
    "validation_status": [
    {
        "errors": [
        {
            "message": "Can not find required field id"
        }]
    }]
}

So this pull request will fixed this issue.

Tested with 9.0 and 10.0 API version.