### PR TITLE
Refactoring out usages of \Magento\Catalog\Model\Product::load($id)

### DIFF
--- a/Block/Pixel/InitiateCheckout.php
+++ b/Block/Pixel/InitiateCheckout.php
@@ -15,9 +15,8 @@ class InitiateCheckout extends Common
         $productIds = [];
         $cart = $this->fbeHelper->getObject(\Magento\Checkout\Model\Cart::class);
         $items = $cart->getQuote()->getAllVisibleItems();
-        $productModel = $this->fbeHelper->getObject(\Magento\Catalog\Model\Product::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $productIds[] = $product->getId();
         }
         return $this->arrayToCommaSeparatedStringValues($productIds);
@@ -49,10 +48,9 @@ class InitiateCheckout extends Common
         }
         $contents = [];
         $items = $cart->getQuote()->getAllVisibleItems();
-        $productModel = $this->fbeHelper->getObject(\Magento\Catalog\Model\Product::class);
         $priceHelper = $this->objectManager->get(\Magento\Framework\Pricing\Helper\Data::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $price = $priceHelper->currency($product->getFinalPrice(), false, false);
             $content = '{id:"' . $product->getId() . '",quantity:' . (int)$item->getQty()
                     . ',item_price:' . $price . "}";

--- a/Block/Pixel/Purchase.php
+++ b/Block/Pixel/Purchase.php
@@ -20,10 +20,8 @@ class Purchase extends Common
         $order = $this->fbeHelper->getObject(\Magento\Checkout\Model\Session::class)->getLastRealOrder();
         if ($order) {
             $items = $order->getItemsCollection();
-            $productModel = $this->fbeHelper->getObject(Product::class);
             foreach ($items as $item) {
-                // @todo do not load product model in loop - this can be a performance killer, use product collection
-                $product = $productModel->load($item->getProductId());
+                $product = $item->getProduct();
                 $productIds[] = $product->getId();
             }
         }
@@ -53,11 +51,10 @@ class Purchase extends Common
         if ($order) {
             $priceHelper = $this->objectManager->get(\Magento\Framework\Pricing\Helper\Data::class);
             $items = $order->getItemsCollection();
-            $productModel = $this->fbeHelper->getObject(Product::class);
             foreach ($items as $item) {
                 /** @var Product $product */
                 // @todo reuse results from self::getContentIDs()
-                $product = $productModel->load($item->getProductId());
+                $product = $item->getProduct();
                 $price = $priceHelper->currency($product->getFinalPrice(), false, false);
                 $content = '{id:"' . $product->getId() . '",quantity:' . (int)$item->getQtyOrdered()
                         . ',item_price:' . $price . '}';

--- a/Controller/Pixel/ProductInfoForAddToCart.php
+++ b/Controller/Pixel/ProductInfoForAddToCart.php
@@ -15,19 +15,22 @@ class ProductInfoForAddToCart extends \Magento\Framework\App\Action\Action
     protected $_productFactory;
     protected $_fbeHelper;
     protected $_formKeyValidator;
+    protected $_magentoDataHelper;
 
     public function __construct(
         \Magento\Framework\App\Action\Context $context,
         \Magento\Framework\Controller\Result\JsonFactory $resultJsonFactory,
         \Magento\Catalog\Model\ProductFactory $productFactory,
         FBEHelper $helper,
-        \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator
+        \Magento\Framework\Data\Form\FormKey\Validator $formKeyValidator,
+        \Facebook\BusinessExtension\Helper\MagentoDataHelper $magentoDataHelper
     ) {
         parent::__construct($context);
         $this->_resultJsonFactory = $resultJsonFactory;
         $this->_productFactory = $productFactory;
         $this->_fbeHelper = $helper;
         $this->_formKeyValidator = $formKeyValidator;
+        $this->_magentoDataHelper = $magentoDataHelper;
     }
 
     private function getCategory($product)
@@ -60,8 +63,7 @@ class ProductInfoForAddToCart extends \Magento\Framework\App\Action\Action
     private function getProductInfo($product_sku)
     {
         $response_data = [];
-        $product = $this->_productFactory->create();
-        $product->load($product->getIdBySku($product_sku));
+        $product = $this->_magentoDataHelper->getProductWithSku($product_sku);
         if ($product->getId()) {
             $response_data['id'] = $product->getId();
             $response_data['name'] = $product->getName();

--- a/Helper/MagentoDataHelper.php
+++ b/Helper/MagentoDataHelper.php
@@ -40,6 +40,11 @@ class MagentoDataHelper extends AbstractHelper
     protected $customerMetadata;
 
     /**
+     * @var \Magento\Catalog\Api\ProductRepositoryInterface
+     */
+    protected $productRepository;
+
+    /**
      * MagentoDataHelper constructor
      *
      * @param Context $context
@@ -55,7 +60,8 @@ class MagentoDataHelper extends AbstractHelper
         \Facebook\BusinessExtension\Logger\Logger $logger,
         \Magento\Catalog\Model\ProductFactory $productFactory,
         \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Customer\Api\CustomerMetadataInterface $customerMetadata
+        \Magento\Customer\Api\CustomerMetadataInterface $customerMetadata,
+        \Magento\Catalog\Api\ProductRepositoryInterface $productRepository
     ) {
         parent::__construct($context);
         $this->objectManager = $objectManager;
@@ -63,6 +69,7 @@ class MagentoDataHelper extends AbstractHelper
         $this->productFactory = $productFactory;
         $this->storeManager = $storeManager;
         $this->customerMetadata = $customerMetadata;
+        $this->productRepository = $productRepository;
     }
 
     /**
@@ -121,8 +128,7 @@ class MagentoDataHelper extends AbstractHelper
      */
     public function getProductWithSku($productSku)
     {
-        $product = $this->productFactory->create();
-        $product->load($product->getIdBySku($productSku));
+        $product = $this->productRepository->get($productSku);
         return $product;
     }
 
@@ -184,9 +190,8 @@ class MagentoDataHelper extends AbstractHelper
             return null;
         }
         $items = $cart->getQuote()->getAllVisibleItems();
-        $productModel = $this->objectManager->get(\Magento\Catalog\Model\Product::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $productIds[] = $product->getId();
         }
         return $productIds;
@@ -241,10 +246,9 @@ class MagentoDataHelper extends AbstractHelper
         }
         $contents = [];
         $items = $cart->getQuote()->getAllVisibleItems();
-        $productModel = $this->objectManager->get(\Magento\Catalog\Model\Product::class);
         $priceHelper = $this->objectManager->get(\Magento\Framework\Pricing\Helper\Data::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $contents[] = [
                 'product_id' => $product->getId(),
                 'quantity' => $item->getQty(),
@@ -266,9 +270,8 @@ class MagentoDataHelper extends AbstractHelper
         }
         $productIds = [];
         $items = $order->getAllVisibleItems();
-        $productModel = $this->objectManager->get(\Magento\Catalog\Model\Product::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $productIds[] = $product->getId();
         }
         return $productIds;
@@ -306,10 +309,9 @@ class MagentoDataHelper extends AbstractHelper
         }
         $contents = [];
         $items = $order->getAllVisibleItems();
-        $productModel = $this->objectManager->get(\Magento\Catalog\Model\Product::class);
         $priceHelper = $this->objectManager->get(\Magento\Framework\Pricing\Helper\Data::class);
         foreach ($items as $item) {
-            $product = $productModel->load($item->getProductId());
+            $product = $item->getProduct();
             $contents[] = [
                 'product_id' => $product->getId(),
                 'quantity' => (int)$item->getQtyOrdered(),


### PR DESCRIPTION
This is a pull request for issue #33 

Some more work needs to be done to fully de-couple the Object Manager from this extension, but this will at least stop products from being loaded multiple times when unnecessary.