### PR TITLE
Set Right SalePrice

### DIFF
--- a/Model/Product/Feed/Builder.php
+++ b/Model/Product/Feed/Builder.php
@@ -150,7 +150,11 @@ class Builder
      */
     protected function getProductSalePrice(Product $product)
     {
-        return $product->getSpecialPrice() ? $this->builderTools->formatPrice($product->getSpecialPrice()) : '';
+        if ($product->getRegularPrice() > $product->getFinalPrice()) {
+            return $this->builderTools->formatPrice($product->getFinalPrice());
+        }
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
Getting Sale Price with FinalPrice method instead of SpecialPrice because last one give wrong price, based on field in product and ignoring "From/To Dates". Also Special Prices not affect pricing rules.

#### Related Issues:

1. #31 
2. #40 


fix-get-correct-special-price