### PR TITLE
Fix: catalog_product_super_link table doesn't exists

### DIFF
--- a/Model/Product/Feed/ProductRetriever/Simple.php
+++ b/Model/Product/Feed/ProductRetriever/Simple.php
@@ -60,7 +60,7 @@ class Simple implements ProductRetrieverInterface
             ->setStoreId($storeId);
 
         $collection
-            ->getSelect()->joinLeft(['l' => 'catalog_product_super_link'], 'e.entity_id = l.product_id')
+            ->getSelect()->joinLeft(['l' => $collection->getTable('catalog_product_super_link')], 'e.entity_id = l.product_id')
             ->where('l.product_id IS NULL')
             ->order(new \Zend_Db_Expr('e.updated_at desc'))
             ->limit($limit, $offset);


### PR DESCRIPTION
If to use a prefix for the Magento 2 database tables there is an error when pushing products to facebook, example:
![image](https://user-images.githubusercontent.com/9151916/164734608-f8c6e7fd-4df6-4317-819b-285e8b1082e9.png)

To fix it, the table name should be processed with the function getTable

The same issue is also described here https://github.com/facebookincubator/facebook-for-magento2/issues/103 
