### PR TITLE
Fix PHP8.1 Deprecated Functionality: strtolower(): Passing null

### DIFF
--- a/Helper/MagentoDataHelper.php
+++ b/Helper/MagentoDataHelper.php
@@ -478,7 +478,7 @@ class MagentoDataHelper extends AbstractHelper
     }
 
     private function hashValue($string){
-        return hash('sha256', strtolower($string));
+        return hash('sha256', strtolower((string)$string));
     }
 
     // TODO Remaining user/custom data methods that can be obtained using Magento.


### PR DESCRIPTION
Fixes error `Deprecated Functionality: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in vendor/facebook/facebook-for-magento2/Helper/MagentoDataHelper.php on line 481` by casting the parameter passed to strtolower to string.